### PR TITLE
Add special lecture keywords handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,19 @@ console.log(JSON.stringify(data, null, 2));
 ```
 
 This data is publically available on the KU Leuven website, so there should be no privacy concerns. However, if you are a teacher and you do not want your name to be displayed, please let me know at [rooster@gbgk.me](mailto:rooster@gbgk.me) and I will remove it
+
+## Handling Special Lecture Keywords
+
+Rooster now includes a feature to handle special lecture keywords like 'practical lecture' and 'tutorial'. When these keywords are found in the event summary, the corresponding text is added in parentheses to the subject name.
+
+### Example
+
+If the event is a practical lecture on microeconomics, the name will be modified as follows:
+
+- Original: "Microeconomics for Business practical lecture"
+- Modified: "Microeconomics for Business (Practice)"
+
+Similarly, for tutorials:
+
+- Original: "Microeconomics for Business tutorial"
+- Modified: "Microeconomics for Business (Tutorial)"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@ import ical from 'ical.js';
 import bbaSubjects from './programmes/bba';
 import webpage from './webpage';
 
+const specialLectureKeywords = {
+	'practical lecture': 'Practice',
+	'tutorial': 'Tutorial'
+};
+
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
 		const url = new URL(request.url);
@@ -44,6 +49,13 @@ export default {
 				const originalSummary = event.summary;
 
 				event.summary = subject ? subject.subjectName : originalSummary.split(',')[0].split(' ')[1];
+
+				for (const [keyword, text] of Object.entries(specialLectureKeywords)) {
+					if (originalSummary.toLowerCase().includes(keyword)) {
+						event.summary += ` (${text})`;
+						break;
+					}
+				}
 
 				if (subject) {
 					event.description = `${subject.teachers.map((teacher) => `${teacher.name}\n${teacher.profile}`).join('\n\n')}


### PR DESCRIPTION
Add a feature to handle special lecture keywords in event summaries.

* **src/index.ts**
  - Add a dictionary named `specialLectureKeywords` with keywords 'practical lecture' and 'tutorial' and corresponding text 'Practice' and 'Tutorial'.
  - Update the logic in the `fetch` function to check for these keywords in the event summary.
  - If a keyword is found, add the corresponding text in parentheses to the subject name.

* **README.md**
  - Add a section explaining the new feature of handling special lecture keywords.
  - Include an example of how the event name will be modified based on the keywords.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/breitburg/rooster?shareId=994e6ed9-fd0b-421c-a820-4be7d95acb43).