### PR TITLE
Replace 'Lessons Schedule' with 'Lesson Timetable'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,12 @@ import bbaSubjects from './programmes/bba';
 import webpage from './webpage';
 import iab from './inappbrowser';
 
-const specialLectureKeywords = {
+const SPECIAL_LECTURE_KEYWORDS = {
 	'practical lecture': 'Practice',
 	'tutorial': 'Tutorial'
 };
+
+const LESSON_TIMETABLE = 'Lesson Timetable';
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
@@ -45,8 +47,8 @@ export default {
 			const comp = new ical.Component(jcalData);
 			const vevents = comp.getAllSubcomponents('vevent');
 
-			comp.updatePropertyWithValue('SUMMARY', 'Lessons Schedule');
-			comp.updatePropertyWithValue('X-WR-CALNAME', 'Lessons Schedule');
+			comp.updatePropertyWithValue('SUMMARY', LESSON_TIMETABLE);
+			comp.updatePropertyWithValue('X-WR-CALNAME', LESSON_TIMETABLE);
 
 			vevents.forEach((vevent) => {
 				const event = new ical.Event(vevent);
@@ -59,7 +61,7 @@ export default {
 
 				event.summary = subject ? subject.subjectName : originalSummary.split(',')[0].split(' ')[1];
 
-				for (const [keyword, text] of Object.entries(specialLectureKeywords)) {
+				for (const [keyword, text] of Object.entries(SPECIAL_LECTURE_KEYWORDS)) {
 					if (originalSummary.toLowerCase().includes(keyword)) {
 						event.summary += ` (${text})`;
 						break;


### PR DESCRIPTION
Replace 'Lessons Schedule' with 'Lesson Timetable' in `src/index.ts`.

* Extract 'Lesson Timetable' into a new constant named `LESSON_TIMETABLE`.
* Rename `specialLectureKeywords` to `SPECIAL_LECTURE_KEYWORDS` for consistency.
* Update `comp.updatePropertyWithValue` method calls to use `LESSON_TIMETABLE` for 'SUMMARY' and 'X-WR-CALNAME' properties.
* Update references to `specialLectureKeywords` to use `SPECIAL_LECTURE_KEYWORDS`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/breitburg/rooster?shareId=9400ee3c-89a7-4081-a102-eb7ab3065e29).